### PR TITLE
examples: add a new example list-pods

### DIFF
--- a/examples/get-secret.rs
+++ b/examples/get-secret.rs
@@ -4,11 +4,19 @@ use kubeclient::prelude::*;
 use kubeclient::errors::*;
 
 fn get_secret(name: &str) -> Result<bool> {
-    let kube = Kubernetes::load_conf("admin.conf")?;
+    // filename is set to $KUBECONFIG if the env var is available.
+    // Otherwise it falls back to "admin.conf".
+    let filename = env::var("KUBECONFIG").ok();
+    let filename = filename
+        .as_ref()
+        .map(String::as_str)
+        .and_then(|s| if s.is_empty() { None } else { Some(s) })
+        .unwrap_or("admin.conf");
+    let kube = Kubernetes::load_conf(filename)?;
 
     if kube.healthy()? {
         let __secret = kube.secrets().get(name)?;
-        return Ok(true)
+        return Ok(true);
     }
 
     Ok(false)
@@ -22,7 +30,7 @@ fn main() {
     };
 
     match get_secret(secret_name) {
-        Ok(s)  => println!("The secret {} exists {}", secret_name, s),
+        Ok(s) => println!("The secret {} exists {}", secret_name, s),
         Err(e) => println!("Error: {}", e),
     }
 }

--- a/examples/list-nodes.rs
+++ b/examples/list-nodes.rs
@@ -1,9 +1,18 @@
 extern crate kubeclient;
 use kubeclient::prelude::*;
 use kubeclient::errors::*;
+use std::env;
 
 fn run_main() -> Result<i32> {
-    let kube = Kubernetes::load_conf("admin.conf")?;
+    // filename is set to $KUBECONFIG if the env var is available.
+    // Otherwise it falls back to "admin.conf".
+    let filename = env::var("KUBECONFIG").ok();
+    let filename = filename
+        .as_ref()
+        .map(String::as_str)
+        .and_then(|s| if s.is_empty() { None } else { Some(s) })
+        .unwrap_or("admin.conf");
+    let kube = Kubernetes::load_conf(filename)?;
 
     if kube.healthy()? {
         for node in kube.nodes().list(None)? {
@@ -16,8 +25,7 @@ fn run_main() -> Result<i32> {
 
 fn main() {
     match run_main() {
-        Ok(n)  => println!("Success error code is {}", n),
+        Ok(n) => println!("Success error code is {}", n),
         Err(e) => println!("Error: {}", e),
     }
 }
-

--- a/examples/list-pods.rs
+++ b/examples/list-pods.rs
@@ -1,0 +1,31 @@
+extern crate kubeclient;
+use kubeclient::prelude::*;
+use kubeclient::errors::*;
+use std::env;
+
+fn run_list_pods() -> Result<i32> {
+    // filename is set to $KUBECONFIG if the env var is available.
+    // Otherwise it falls back to "admin.conf".
+    let filename = env::var("KUBECONFIG").ok();
+    let filename = filename
+        .as_ref()
+        .map(String::as_str)
+        .and_then(|s| if s.is_empty() { None } else { Some(s) })
+        .unwrap_or("admin.conf");
+    let kube = Kubernetes::load_conf(filename)?;
+
+    if kube.healthy()? {
+        for pod in kube.pods().namespace("default").list(None)? {
+            println!("found pod: {:?}", pod);
+        }
+    }
+
+    Ok(0)
+}
+
+fn main() {
+    match run_list_pods() {
+        Ok(n) => println!("Success error code is {}", n),
+        Err(e) => println!("Error: {}", e),
+    }
+}


### PR DESCRIPTION
This example list-pods is equivalent to running `kubectl get pods`. Make use of `$KUBECONFIG` env variable like get-secret and list-nodes. If the variable is not set or is empty, we fall back to "admin.conf" like previously. The namespace "default" is used.

Also update existing examples to handle `$KUBECONFIG`.