### PR TITLE
"Preferences" is optional and can be missing in some cases.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct KubeConfig {
     pub kind: Option<String>,
     #[serde(rename = "apiVersion")]
     pub api_version: Option<String>,
-    pub preferences: Preferences,
+    pub preferences: Option<Preferences>,
     pub clusters: Vec<NamedCluster>,
     pub users: Vec<NamedAuthInfo>,
     pub contexts: Vec<NamedContext>,


### PR DESCRIPTION
In my environment this field is missing in some configs and this breaks `kubeclient-rs`.
Wrapping the field in `Option` fixes it.