### PR TITLE
Update for current k8s-openapi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: cargo
 
 rust:
-  - 1.20.0
+  - 1.26.2
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ url_serde = "0.2.0"
 openssl = "0.9.15"
 walkdir = "1.0.7"
 reqwest = "0.8.0"
-k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi-codegen", branch = "master" }
+k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi-codegen", branch = "master", features = ["v1_9"] }

--- a/src/clients/low_level.rs
+++ b/src/clients/low_level.rs
@@ -13,7 +13,7 @@ use url::Url;
 use std::borrow::Borrow;
 use walkdir::WalkDir;
 use errors::*;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,5 @@ pub mod prelude {
 pub use clients::Kubernetes;
 pub use config::KubeConfig;
 pub use errors::Error;
+
+use k8s_openapi::v1_9 as k8s_api;

--- a/src/resources/config_map.rs
+++ b/src/resources/config_map.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::collections::BTreeMap;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static CONFIG_MAP_INFO: KindInfo = KindInfo {
     plural: "configmaps",

--- a/src/resources/daemon_set.rs
+++ b/src/resources/daemon_set.rs
@@ -1,6 +1,6 @@
 use super::*;
-use k8s_openapi::api::apps::v1beta2::{DaemonSetSpec, DaemonSetStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use ::k8s_api::api::apps::v1beta2::{DaemonSetSpec, DaemonSetStatus};
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static DAEMON_SET_INFO: KindInfo = KindInfo {
     plural: "daemonsets",

--- a/src/resources/deployment.rs
+++ b/src/resources/deployment.rs
@@ -1,7 +1,7 @@
 use super::*;
-use k8s_openapi::api::apps::v1::{DeploymentSpec, DeploymentStatus};
-use k8s_openapi::api::apps::v1beta1::{ScaleSpec, ScaleStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::api::apps::v1::{DeploymentSpec, DeploymentStatus};
+use k8s_api::api::apps::v1beta1::{ScaleSpec, ScaleStatus};
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static DEPLOYMENT_INFO: KindInfo = KindInfo {
     plural: "deployments",

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -16,7 +16,7 @@ pub use self::network_policy::*;
 pub use self::pod::*;
 pub use self::service::*;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::fmt;

--- a/src/resources/network_policy.rs
+++ b/src/resources/network_policy.rs
@@ -1,6 +1,6 @@
 use super::*;
-use k8s_openapi::api::networking::v1::NetworkPolicySpec;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::api::networking::v1::NetworkPolicySpec;
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static NETWORK_POLICY_INFO: KindInfo = KindInfo {
     plural: "networkpolicies",

--- a/src/resources/node.rs
+++ b/src/resources/node.rs
@@ -1,6 +1,6 @@
 use super::*;
-use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::api::core::v1::{NodeSpec, NodeStatus};
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static NODE_INFO: KindInfo = KindInfo {
     plural: "nodes",

--- a/src/resources/pod.rs
+++ b/src/resources/pod.rs
@@ -1,6 +1,6 @@
 use super::*;
-use k8s_openapi::api::core::v1::{PodSpec, PodStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::api::core::v1::{PodSpec, PodStatus};
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static POD_INFO: KindInfo = KindInfo {
     plural: "pods",

--- a/src/resources/secret.rs
+++ b/src/resources/secret.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::collections::BTreeMap;
 use base64;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static SECRET_INFO: KindInfo = KindInfo {
     plural: "secrets",

--- a/src/resources/service.rs
+++ b/src/resources/service.rs
@@ -1,6 +1,6 @@
 use super::*;
-use k8s_openapi::api::core::v1::{ServiceSpec, ServiceStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_api::api::core::v1::{ServiceSpec, ServiceStatus};
+use k8s_api::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
 pub(crate) static SERVICE_INFO: KindInfo = KindInfo {
     plural: "services",


### PR DESCRIPTION
This currently sets the used k8s version to 1.9. I've tried making it configurable via a feature, but that turned out to be hard since features should be additive (so it should be possible to activate e.g. both the v1_9 and the v1_10 feature).